### PR TITLE
Error management

### DIFF
--- a/examples/trk_header.rs
+++ b/examples/trk_header.rs
@@ -37,7 +37,8 @@ fn main() {
 
     let f = File::open(args.get_str("<input>")).expect("Can't read trk file.");
     let mut reader = BufReader::new(f);
-    let (header, endianness) = CHeader::read(&mut reader);
+    let (header, endianness) = CHeader::read(&mut reader)
+        .expect("Read header");
 
     if print_all {
         println!("---------- Actual fields ----------");

--- a/examples/trk_n_first.rs
+++ b/examples/trk_n_first.rs
@@ -46,7 +46,7 @@ fn main() {
     let upto = args.get_str("--upto").parse::<usize>().unwrap_or(usize::MAX);
     let first_part = upto / 2;
 
-    let reader = Reader::new(args.get_str("<input>"));
+    let reader = Reader::new(args.get_str("<input>")).expect("Read header");
     for (i, streamline) in reader.into_iter().enumerate() {
         let len = streamline.len();
         if len > upto {

--- a/examples/trk_subsampler.rs
+++ b/examples/trk_subsampler.rs
@@ -36,7 +36,7 @@ fn main() {
         panic!("Input trk '{:?}' doesn't exist.", input);
     }
 
-    let reader = Reader::new(args.get_str("<input>"));
+    let reader = Reader::new(args.get_str("<input>")).expect("Read header");
     let mut writer = Writer::new(
         args.get_str("<output>"), Some(reader.header.clone()));
 

--- a/examples/trk_subsampler.rs
+++ b/examples/trk_subsampler.rs
@@ -38,7 +38,7 @@ fn main() {
 
     let reader = Reader::new(args.get_str("<input>")).expect("Read header");
     let mut writer = Writer::new(
-        args.get_str("<output>"), Some(reader.header.clone()));
+        args.get_str("<output>"), Some(reader.header.clone())).unwrap();
 
     if let Ok(percent) = args.get_str("--percent").parse::<f32>() {
         let percent = percent / 100.0;

--- a/src/cheader.rs
+++ b/src/cheader.rs
@@ -82,9 +82,10 @@ impl CHeader {
         }
     }
 
-    pub fn seek_n_count_field(f: &mut BufWriter<File>) {
+    pub fn seek_n_count_field(f: &mut BufWriter<File>) -> Result<()> {
         let n_count_offset = (HEADER_SIZE - 12) as u64;
-        f.seek(SeekFrom::Start(n_count_offset)).unwrap();
+        f.seek(SeekFrom::Start(n_count_offset))?;
+        Ok(())
     }
 
     pub fn get_scalars_name(&self) -> Vec<String> {

--- a/src/cheader.rs
+++ b/src/cheader.rs
@@ -183,7 +183,7 @@ impl CHeader {
         Ok(header)
     }
 
-    pub fn write<W: WriteBytesExt>(&self, writer: &mut W) {
+    pub fn write<W: WriteBytesExt>(&self, writer: &mut W) -> Result<()> {
         // Because we don't handle scalars and properties for now, we must
         // erase them from the header. We can't actually erase them without
         // being `mut` though, so we write a modified copy.
@@ -195,39 +195,41 @@ impl CHeader {
             ..self.clone()
         };
 
-        writer.write(&header.id_string).unwrap();
+        writer.write(&header.id_string)?;
         for i in &header.dim {
-            writer.write_i16::<LittleEndian>(*i).unwrap();
+            writer.write_i16::<LittleEndian>(*i)?;
         }
         for f in &header.voxel_size {
-            writer.write_f32::<LittleEndian>(*f).unwrap();
+            writer.write_f32::<LittleEndian>(*f)?;
         }
         for f in &header.origin {
-            writer.write_f32::<LittleEndian>(*f).unwrap();
+            writer.write_f32::<LittleEndian>(*f)?;
         }
-        writer.write_i16::<LittleEndian>(header.n_scalars).unwrap();
-        writer.write(&header.scalar_name).unwrap();
-        writer.write_i16::<LittleEndian>(header.n_properties).unwrap();
-        writer.write(&header.property_name).unwrap();
+        writer.write_i16::<LittleEndian>(header.n_scalars)?;
+        writer.write(&header.scalar_name)?;
+        writer.write_i16::<LittleEndian>(header.n_properties)?;
+        writer.write(&header.property_name)?;
         for f in &header.vox_to_ras {
-            writer.write_f32::<LittleEndian>(*f).unwrap();
+            writer.write_f32::<LittleEndian>(*f)?;
         }
-        writer.write(&header.reserved).unwrap();
-        writer.write(&header.voxel_order).unwrap();
-        writer.write(&header.pad2).unwrap();
+        writer.write(&header.reserved)?;
+        writer.write(&header.voxel_order)?;
+        writer.write(&header.pad2)?;
         for f in &header.image_orientation_patient {
-            writer.write_f32::<LittleEndian>(*f).unwrap();
+            writer.write_f32::<LittleEndian>(*f)?;
         }
-        writer.write(&header.pad1).unwrap();
-        writer.write_u8(header.invert_x).unwrap();
-        writer.write_u8(header.invert_y).unwrap();
-        writer.write_u8(header.invert_z).unwrap();
-        writer.write_u8(header.swap_x).unwrap();
-        writer.write_u8(header.swap_y).unwrap();
-        writer.write_u8(header.swap_z).unwrap();
-        writer.write_i32::<LittleEndian>(header.n_count).unwrap();
-        writer.write_i32::<LittleEndian>(header.version).unwrap();
-        writer.write_i32::<LittleEndian>(header.hdr_size).unwrap();
+        writer.write(&header.pad1)?;
+        writer.write_u8(header.invert_x)?;
+        writer.write_u8(header.invert_y)?;
+        writer.write_u8(header.invert_z)?;
+        writer.write_u8(header.swap_x)?;
+        writer.write_u8(header.swap_y)?;
+        writer.write_u8(header.swap_z)?;
+        writer.write_i32::<LittleEndian>(header.n_count)?;
+        writer.write_i32::<LittleEndian>(header.version)?;
+        writer.write_i32::<LittleEndian>(header.hdr_size)?;
+
+        Ok(())
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,6 +1,6 @@
 
 use std::fs::{File};
-use std::io::{BufReader};
+use std::io::{BufReader, Result};
 
 use byteorder::{WriteBytesExt};
 #[cfg(feature = "use_nifti")] use nifti::NiftiHeader;
@@ -37,8 +37,8 @@ impl Header {
         }
     }
 
-    pub fn read(reader: &mut BufReader<File>) -> (Header, Endianness) {
-        let (c_header, endianness) = CHeader::read(reader);
+    pub fn read(reader: &mut BufReader<File>) -> Result<(Header, Endianness)> {
+        let (c_header, endianness) = CHeader::read(reader)?;
         let affine4 = c_header.get_affine();
         let (affine, translation) = get_affine_and_translation(&affine4);
         let nb_streamlines = c_header.n_count as usize;
@@ -53,7 +53,7 @@ impl Header {
             c_header, affine4, affine, translation,
             nb_streamlines, scalars, properties
         };
-        (header, endianness)
+        Ok((header, endianness))
     }
 
     pub fn write<W: WriteBytesExt>(&self, writer: &mut W) {

--- a/src/header.rs
+++ b/src/header.rs
@@ -56,8 +56,8 @@ impl Header {
         Ok((header, endianness))
     }
 
-    pub fn write<W: WriteBytesExt>(&self, writer: &mut W) {
-        self.c_header.write(writer);
+    pub fn write<W: WriteBytesExt>(&self, writer: &mut W) -> Result<()> {
+        Ok(self.c_header.write(writer)?)
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,5 @@
-
-use std::fs::{File};
-use std::io::BufReader;
+use std::fs::File;
+use std::io::{BufReader, Result};
 use std::path::Path;
 
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
@@ -20,19 +19,19 @@ pub struct Reader {
 }
 
 impl Reader {
-    pub fn new<P: AsRef<Path>>(path: P) -> Reader {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Reader> {
         let f = File::open(path).expect("Can't read trk file.");
         let mut reader = BufReader::new(f);
 
-        let (header, endianness) = Header::read(&mut reader);
+        let (header, endianness) = Header::read(&mut reader)?;
         let affine = header.affine;
         let translation = header.translation;
         let nb_floats_per_point = 3 + header.scalars.len() as usize;
 
-        Reader {
+        Ok(Reader {
             reader, endianness, header, affine, translation,
             nb_floats_per_point, float_buffer: Vec::with_capacity(300)
-        }
+        })
     }
 
     pub fn read_all(&mut self) -> Streamlines {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -16,7 +16,10 @@ pub struct Writer {
 }
 
 impl Writer {
-    pub fn new<P: AsRef<Path>>(path: P, reference: Option<Header>) -> Result<Writer> {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        reference: Option<Header>
+    ) -> Result<Writer> {
         let f = File::create(path).expect("Can't create new trk file.");
         let mut writer = BufWriter::new(f);
 
@@ -27,7 +30,8 @@ impl Writer {
         header.write(&mut writer)?;
 
         // We are only interested in the inversed affine
-        let affine4 = header.affine4.try_inverse().unwrap();
+        let affine4 = header.affine4.try_inverse().expect(
+            "Unable to inverse 4x4 affine matrix");
         let (affine, translation) = get_affine_and_translation(&affine4);
 
         Ok(Writer { writer, affine4, affine, translation, real_n_count: 0 })

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,6 +1,5 @@
-
 use std::fs::File;
-use std::io::BufWriter;
+use std::io::{BufWriter, Result};
 use std::path::Path;
 
 use byteorder::{LittleEndian, WriteBytesExt};
@@ -17,7 +16,7 @@ pub struct Writer {
 }
 
 impl Writer {
-    pub fn new<P: AsRef<Path>>(path: P, reference: Option<Header>) -> Writer {
+    pub fn new<P: AsRef<Path>>(path: P, reference: Option<Header>) -> Result<Writer> {
         let f = File::create(path).expect("Can't create new trk file.");
         let mut writer = BufWriter::new(f);
 
@@ -25,13 +24,13 @@ impl Writer {
             Some(r) => r,
             None => Header::default()
         };
-        header.write(&mut writer);
+        header.write(&mut writer)?;
 
         // We are only interested in the inversed affine
         let affine4 = header.affine4.try_inverse().unwrap();
         let (affine, translation) = get_affine_and_translation(&affine4);
 
-        Writer { writer, affine4, affine, translation, real_n_count: 0 }
+        Ok(Writer { writer, affine4, affine, translation, real_n_count: 0 })
     }
 
     pub fn apply_affine(&mut self, affine: &Affine4) {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -76,7 +76,9 @@ impl Writer {
 // Finally write `n_count`
 impl Drop for Writer {
     fn drop(&mut self) {
-        CHeader::seek_n_count_field(&mut self.writer);
-        self.writer.write_i32::<LittleEndian>(self.real_n_count).unwrap();
+        CHeader::seek_n_count_field(&mut self.writer).expect(
+            "Unable to seek to 'n_count' field before closing trk file.");
+        self.writer.write_i32::<LittleEndian>(self.real_n_count).expect(
+            "Unable to write 'n_count' field before closing trk file.");
     }
 }

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -19,7 +19,8 @@ mod nifti_tests {
         let write_to = get_random_trk_path();
 
         {
-            let mut writer = Writer::new(&write_to, Some(Header::from_nifti(&header)));
+            let mut writer = Writer::new(
+                &write_to, Some(Header::from_nifti(&header))).unwrap();
             writer.apply_affine(&raw_affine_from_nifti(&header));
             writer.write(&[Point::new(13.75, 27.90, 51.55),
                            Point::new(14.00, 27.95, 51.98),

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -12,6 +12,6 @@ pub fn get_random_trk_path() -> String {
 }
 
 pub fn load_trk(path: &str) -> (Header, Streamlines) {
-    let mut reader = Reader::new(path);
+    let mut reader = Reader::new(path).unwrap();
     (reader.header.clone(), reader.read_all())
 }

--- a/tests/trk_read.rs
+++ b/tests/trk_read.rs
@@ -127,6 +127,7 @@ fn test_load_complex_big_endian() {
     assert_eq!(streamlines[0], first);
     assert_eq!(streamlines[1], second);
     assert_eq!(streamlines[2], third);
+    check_complex_scalars_and_properties(reader.header);
 
     // Test generator
     for (i, streamline) in Reader::new(
@@ -141,8 +142,6 @@ fn test_load_complex_big_endian() {
             panic!("Failed test.");
         }
     }
-
-    check_complex_scalars_and_properties(reader.header);
 }
 
 fn check_complex_scalars_and_properties(header: Header) {

--- a/tests/trk_read.rs
+++ b/tests/trk_read.rs
@@ -5,14 +5,15 @@ use trk_io::{Affine, ArraySequence, Header, Point, Reader, Translation};
 
 #[test]
 fn test_load_empty() {
-    let streamlines = Reader::new("data/empty.trk").read_all();
+    let streamlines = Reader::new("data/empty.trk").unwrap().read_all();
     assert_eq!(streamlines.len(), 0);
     for _ in &streamlines {
         panic!("Failed test.");
     }
 
     // Test generator
-    for _ in Reader::new("data/empty.trk").into_iter() {
+    let reader = Reader::new("data/empty.trk").unwrap();
+    for _ in reader.into_iter() {
         panic!("Failed test.");
     }
 }
@@ -27,15 +28,15 @@ fn test_load_simple() {
                  Point::new(9.0, 10.0, 11.0),
                  Point::new(12.0, 13.0, 14.0)];
 
-    let streamlines = Reader::new("data/simple.trk").read_all();
+    let streamlines = Reader::new("data/simple.trk").unwrap().read_all();
     assert_eq!(streamlines.len(), 3);
     assert_eq!(streamlines[0], first);
     assert_eq!(streamlines[1], second);
     assert_eq!(streamlines[2], third);
 
     // Test generator
-    for (i, streamline)
-            in Reader::new("data/empty.trk").into_iter().enumerate() {
+    let reader = Reader::new("data/empty.trk").unwrap();
+    for (i, streamline) in reader.into_iter().enumerate() {
         if i == 0 {
             assert_eq!(streamline, first);
         } else if i == 1 {
@@ -50,7 +51,7 @@ fn test_load_simple() {
 
 #[test]
 fn test_load_standard() {
-    let mut reader = Reader::new("data/standard.trk");
+    let mut reader = Reader::new("data/standard.trk").unwrap();
     let streamlines = reader.read_all();
     assert_eq!(reader.affine, Affine::new(1.0, 0.0, 0.0,
                                           0.0, 1.0, 0.0,
@@ -66,14 +67,15 @@ fn test_load_standard() {
                                 Point::new(0.5, -1.5, 3.0)]);
 
     // Test generator
-    for streamline in Reader::new("data/empty.trk").into_iter() {
+    let reader = Reader::new("data/empty.trk").unwrap();
+    for streamline in reader.into_iter() {
         assert_eq!(streamline.len(), 3);
     }
 }
 
 #[test]
 fn test_load_standard_lps() {
-    let mut reader = Reader::new("data/standard.LPS.trk");
+    let mut reader = Reader::new("data/standard.LPS.trk").unwrap();
     let streamlines = reader.read_all();
     assert_eq!(reader.affine, Affine::new(-1.0, 0.0, 0.0,
                                           0.0, -1.0, 0.0,
@@ -91,7 +93,7 @@ fn test_load_standard_lps() {
 
 #[test]
 fn test_load_complex() {
-    let mut reader = Reader::new("data/complex.trk");
+    let mut reader = Reader::new("data/complex.trk").unwrap();
     let streamlines = reader.read_all();
     assert_eq!(reader.affine, Affine::new(1.0, 0.0, 0.0,
                                           0.0, 1.0, 0.0,
@@ -121,7 +123,7 @@ fn test_load_complex_big_endian() {
                  Point::new(9.0, 10.0, 11.0),
                  Point::new(12.0, 13.0, 14.0)];
 
-    let mut reader = Reader::new("data/complex_big_endian.trk");
+    let mut reader = Reader::new("data/complex_big_endian.trk").unwrap();
     let streamlines = reader.read_all();
     assert_eq!(streamlines.len(), 3);
     assert_eq!(streamlines[0], first);
@@ -130,8 +132,8 @@ fn test_load_complex_big_endian() {
     check_complex_scalars_and_properties(reader.header);
 
     // Test generator
-    for (i, streamline) in Reader::new(
-            "data/complex_big_endian.trk").into_iter().enumerate() {
+    let reader = Reader::new("data/complex_big_endian.trk").unwrap();
+    for (i, streamline) in reader.into_iter().enumerate() {
         if i == 0 {
             assert_eq!(streamline, first);
         } else if i == 1 {

--- a/tests/trk_write.rs
+++ b/tests/trk_write.rs
@@ -14,7 +14,8 @@ fn test_write_dynamic() {
     let (original_header, original_streamlines) = load_trk("data/simple.trk");
 
     {
-        let mut writer = Writer::new(&write_to, Some(original_header.clone()));
+        let mut writer = Writer::new(
+            &write_to, Some(original_header.clone())).unwrap();
         writer.write_from_iter(
             [Point::new(0.0, 1.0, 2.0)].iter().cloned(), 1);
 
@@ -39,7 +40,8 @@ fn test_write_empty() {
     let (original_header, original_streamlines) = load_trk("data/empty.trk");
 
     {
-        let mut writer = Writer::new(&write_to, Some(original_header.clone()));
+        let mut writer = Writer::new(
+            &write_to, Some(original_header.clone())).unwrap();
         writer.write_all(&Streamlines::new(vec![], vec![]));
     }
 
@@ -54,7 +56,8 @@ fn test_write_simple() {
     let (original_header, original_streamlines) = load_trk("data/simple.trk");
 
     {
-        let mut writer = Writer::new(&write_to, Some(original_header.clone()));
+        let mut writer = Writer::new(
+            &write_to, Some(original_header.clone())).unwrap();
         writer.write_all(&original_streamlines);
     }
 
@@ -70,7 +73,8 @@ fn test_write_standard() {
         load_trk("data/standard.trk");
 
     {
-        let mut writer = Writer::new(&write_to, Some(original_header.clone()));
+        let mut writer = Writer::new(
+            &write_to, Some(original_header.clone())).unwrap();
         writer.write(&original_streamlines[0]);
         writer.write(&original_streamlines[1]);
         writer.write(&original_streamlines[2]);
@@ -90,7 +94,8 @@ fn test_write_standard_lps() {
         load_trk("data/standard.LPS.trk");
 
     {
-        let mut writer = Writer::new(&write_to, Some(original_header.clone()));
+        let mut writer = Writer::new(
+            &write_to, Some(original_header.clone())).unwrap();
         assert_eq!(writer.affine4, Affine4::new(-1.0, 0.0, 0.0, 3.5,
                                                 0.0, -1.0, 0.0, 13.5,
                                                 0.0, 0.0, 1.0, 1.0,
@@ -120,7 +125,8 @@ fn test_write_complex() {
     let (original_header, original_streamlines) = load_trk("data/complex.trk");
 
     {
-        let mut writer = Writer::new(&write_to, Some(original_header.clone()));
+        let mut writer = Writer::new(
+            &write_to, Some(original_header.clone())).unwrap();
         writer.write_all(&original_streamlines);
     }
 


### PR DESCRIPTION
Library in filled with `unwrap()`, which is obviously wrong. This PR doesn't fix everything because the right course of action is still unclear to me, notably in the Reader iterator. It does make the header reader/writer more practical for error management though. All errors elsewhere (streamlines r/w and some other cases) will panic because of a `Option`/`Result` `unwrap()`.

I replaced some `unwrap()` with `expect()`. Of course, it would be better to not panic, but while we do so, `expect()` is a much better choice.