### PR TITLE
Implement the subsampler for the number parameter.

### DIFF
--- a/examples/trk_subsampler.rs
+++ b/examples/trk_subsampler.rs
@@ -76,9 +76,8 @@ fn main() {
         sampled_indices.sort();
 
         let mut reader_iter = reader.into_iter();
-        let mut indices_iter = sampled_indices.into_iter();
-        let mut last: usize = 0;
-        for idx in indices_iter {
+        let mut last = 0;
+        for idx in sampled_indices.into_iter() {
             let streamline = reader_iter.nth(idx - last).unwrap();
             writer.write(&streamline);
             last = idx + 1;

--- a/examples/trk_subsampler.rs
+++ b/examples/trk_subsampler.rs
@@ -59,17 +59,16 @@ fn main() {
         }
     } else if let Ok(nb) = args.get_str("--number").parse::<usize>() {
         let size = reader.header.nb_streamlines;
-        let mut number = nb;
+        let number = size.min(nb);
 
-        if number > size {
+        if nb > size {
             println!(
                 "The number {} exceed the total number of streamlines: {}. \
                  Saving {} streamlines.",
-                number, size, size);
-            number = size;
+                nb, size, size);
         } else if number == 0 {
-            panic!("Saving 0 streamline is not usefull. \
-                    Please change the number of steamlines you want.");
+            panic!("You requested a subsampling of 0 streamline. \
+                    Please ask for any non-zero positive number.");
         }
 
         let mut sampled_indices = rand::seq::sample_indices(&mut rng, size, number);
@@ -77,7 +76,7 @@ fn main() {
 
         let mut reader_iter = reader.into_iter();
         let mut last = 0;
-        for idx in sampled_indices.into_iter() {
+        for idx in sampled_indices {
             let streamline = reader_iter.nth(idx - last).unwrap();
             writer.write(&streamline);
             last = idx + 1;

--- a/examples/trk_subsampler.rs
+++ b/examples/trk_subsampler.rs
@@ -8,6 +8,7 @@ use std::str;
 
 use docopt::Docopt;
 use rand::Rng;
+use rand::SeedableRng;
 
 use trk_io::{Reader, Writer};
 
@@ -15,13 +16,14 @@ static USAGE: &'static str = "
 Subsample a TrackVis (.trk) file
 
 Usage:
-  trk_subsampler <input> <output> (--percent=<p> | --number=<n>)
+  trk_subsampler <input> <output> (--percent=<p> | --number=<n>) [--seed=<s>]
   trk_subsampler (-h | --help)
   trk_subsampler (-v | --version)
 
 Options:
   -p --percent=<p>  Keep only p% of streamlines. Based on rand.
   -n --number=<n>   Keep exactly n streamlines. Deterministic.
+  -s --seed=<s>     Make randomness deterministic [default: 42].
   -h --help         Show this screen.
   -v --version      Show version.
 ";
@@ -42,15 +44,37 @@ fn main() {
 
     if let Ok(percent) = args.get_str("--percent").parse::<f32>() {
         let percent = percent / 100.0;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::weak_rng();
 
         for streamline in reader.into_iter() {
             if rng.gen::<f32>() < percent {
                 writer.write(&streamline);
             }
         }
-    } else if let Ok(_nb) = args.get_str("--number").parse::<usize>() {
-        panic!("Not implemented yet");
+    } else if let Ok(nb) = args.get_str("--number").parse::<usize>() {
+        if let Ok(seed) = args.get_str("--seed").parse::<u8>() {
+            let size = reader.header.nb_streamlines;
+            let mut rng = rand::XorShiftRng::from_seed([seed; 16]);
+
+            let mut sampled_indices = rand::seq::sample_indices(&mut rng, size, nb);
+            sampled_indices.sort();
+
+            let mut iter_indices = sampled_indices.into_iter();
+            let mut index = iter_indices.next();
+
+            for (idx, streamline) in reader.into_iter().enumerate() {
+                if let Some(index_to_save) = index {
+                    if idx == index_to_save {
+                        writer.write(&streamline);
+                        index = iter_indices.next();
+                    }
+                } else {
+                    break;
+                }
+            }
+        } else {
+            panic!("--number need a seed to be deterministic.");
+        }
     } else {
         panic!("--percent or --number can't be parsed to a number");
     }


### PR DESCRIPTION
This implementation is fairly simple and could lead to memory problems if the number of streamlines to keep is huge.