### PR TITLE
WIP len check

### DIFF
--- a/examples/trk_len_check.rs
+++ b/examples/trk_len_check.rs
@@ -1,0 +1,64 @@
+use std::{fs::File, path::Path, str};
+
+use docopt::Docopt;
+
+use trk_io::Reader;
+
+static USAGE: &'static str = "
+Binary to test that reserving a number of points, scalars and properties is
+possible and works 100% of the time.
+
+Usage:
+  trk_len_check <input> [options]
+  trk_len_check (-h | --help)
+  trk_len_check (-v | --version)
+
+Options:
+  -h --help     Show this screen.
+  -v --version  Show version.
+";
+
+fn main() {
+    let version = String::from(env!("CARGO_PKG_VERSION"));
+    let args = Docopt::new(USAGE)
+        .and_then(|dopt| dopt.version(Some(version)).parse())
+        .unwrap_or_else(|e| e.exit());
+    let input = Path::new(args.get_str("<input>"));
+    if !input.exists() {
+        panic!("Input trk '{:?}' doesn't exist.", input);
+    }
+
+    let f = File::open(args.get_str("<input>")).expect("Can't read trk file.");
+    let metadata = f.metadata().unwrap();
+    let nb_bytes = metadata.len() as usize;
+
+    let reader = Reader::new(args.get_str("<input>")).expect("Read header");
+    let header = &reader.header;
+    let nb_scalars = header.scalars_name.len();
+    let nb_properties = header.properties_name.len();
+    let nb_streamlines = header.nb_streamlines;
+    let header_size = header.raw_header().hdr_size as usize;
+
+    let nb_f32s = (nb_bytes - header_size) / 4;
+    let guessed_nb_properties = nb_streamlines * nb_properties;
+
+    // We remove the nb_points count and the properties, se we only have the points and scalars
+    let nb_f32s = nb_f32s - nb_streamlines - guessed_nb_properties;
+    let guessed_nb_points = nb_f32s / (3 + nb_scalars);
+    let guessed_nb_scalars = nb_f32s - (3 * guessed_nb_points);
+
+    let mut real_nb_points = 0;
+    let mut real_nb_scalars = 0;
+    let mut real_nb_properties = 0;
+    for (streamline, scalars, properties) in reader.into_iter() {
+        real_nb_points += streamline.len();
+        for s in &scalars {
+            real_nb_scalars += s.len();
+        }
+        real_nb_properties += properties.len();
+    }
+
+    assert_eq!(guessed_nb_points, real_nb_points);
+    assert_eq!(guessed_nb_scalars, real_nb_scalars);
+    assert_eq!(guessed_nb_properties, real_nb_properties);
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -19,6 +19,7 @@ pub struct Reader {
     pub affine_to_rasmm: Affine,
     pub translation: Translation,
 
+    nb_bytes: usize,
     nb_scalars: usize,
     nb_properties: usize,
     nb_floats_per_point: usize,
@@ -27,7 +28,10 @@ pub struct Reader {
 
 impl Reader {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Reader> {
-        let mut reader = BufReader::new(File::open(&path)?);
+        let f = File::open(&path)?;
+        let nb_bytes = f.metadata().unwrap().len() as usize;
+
+        let mut reader = BufReader::new(f);
         let (header, endianness) = Header::read(&mut reader)?;
         let affine_to_rasmm = header.affine_to_rasmm;
         let translation = header.translation;
@@ -41,6 +45,7 @@ impl Reader {
             header,
             affine_to_rasmm,
             translation,
+            nb_bytes,
             nb_scalars,
             nb_properties,
             nb_floats_per_point,
@@ -56,11 +61,23 @@ impl Reader {
     }
 
     fn read_all_<E: ByteOrder>(&mut self) -> Tractogram {
-        // TODO Anything we can do to reerve?
-        let mut lengths = Vec::new();
-        let mut v = Vec::with_capacity(300);
-        let mut scalars = ArraySequence::with_capacity(300);
-        let mut properties = ArraySequence::with_capacity(300);
+        let nb_scalars = self.header.scalars_name.len();
+        let nb_properties = self.header.properties_name.len();
+        let nb_streamlines = self.header.nb_streamlines;
+        let header_size = self.header.raw_header().hdr_size as usize;
+
+        // We remove the nb_points count and the properties from nb_f32s, se we only have the
+        // points and scalars
+        let guessed_nb_properties = nb_streamlines * nb_properties;
+        let nb_f32s = (self.nb_bytes - header_size) / 4;
+        let nb_f32s = nb_f32s - nb_streamlines - guessed_nb_properties;
+        let guessed_nb_points = nb_f32s / (3 + nb_scalars);
+        let guessed_nb_scalars = nb_f32s - (3 * guessed_nb_points);
+
+        let mut lengths = Vec::with_capacity(nb_streamlines);
+        let mut v = Vec::with_capacity(guessed_nb_points);
+        let mut scalars = ArraySequence::with_capacity(guessed_nb_scalars);
+        let mut properties = ArraySequence::with_capacity(guessed_nb_properties);
         while let Ok(nb_points) = self.reader.read_i32::<E>() {
             lengths.push(nb_points as usize);
             self.read_streamline::<E>(&mut v, &mut scalars, nb_points as usize);


### PR DESCRIPTION
Add an example script that checks if it's possible to allocate all arrays with the exact lengths when reading the whole tractogram. This is still a WIP because I'm currently testing it on various trk.