### PR TITLE
Anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rand = { version = "0.8", default-features = false, features = ["alloc", "getran
 tempfile = "3.2"
 
 [dependencies]
+anyhow = "1.0"
 byteorder = "1.4"
 nalgebra = "0.27"
 

--- a/examples/trk_color.rs
+++ b/examples/trk_color.rs
@@ -1,12 +1,13 @@
+use anyhow::Result;
 use docopt::Docopt;
 use trk_io::{Header, Point, Reader, Writer};
 
 static USAGE: &'static str = "
 Color a TrackVis (.trk) file.
 
-This will add 3 scalars (color_x, color_y, color_z) per point. Please note that
-coloring by 'local' orientation may be useless as some programs already use
-this method by default to color the streamlines.
+This will add 3 scalars (color_x, color_y, color_z) per point. Please note that coloring by 'local'
+orientation may be useless as some programs already use this method by default to color the
+streamlines.
 
 Usage:
   trk_color uniform <r> <g> <b> <input> <output> [options]
@@ -15,35 +16,32 @@ Usage:
   trk_color (-v | --version)
 
 Options:
-  -h --help     Show this screen.
-  -v --version  Show version.
+  -h --help      Show this screen.
+  -v --version   Show version.
 ";
 
-fn main() {
+fn main() -> Result<()> {
     let version = String::from(env!("CARGO_PKG_VERSION"));
     let args = Docopt::new(USAGE)
         .and_then(|dopt| dopt.version(Some(version)).parse())
         .unwrap_or_else(|e| e.exit());
 
-    let input = std::path::Path::new(args.get_str("<input>"));
-    if !input.exists() {
-        panic!("Input trk '{:?}' doesn't exist.", input);
-    }
-
-    let reader = Reader::new(args.get_str("<input>")).expect("Read header");
+    let reader = Reader::new(args.get_str("<input>"))?;
     let mut header = reader.header.clone();
-    header.add_scalar("color_x").unwrap();
-    header.add_scalar("color_y").unwrap();
-    header.add_scalar("color_z").unwrap();
+    header.add_scalar("color_x")?;
+    header.add_scalar("color_y")?;
+    header.add_scalar("color_z")?;
 
     if args.get_bool("uniform") {
-        let r = args.get_str("<r>").parse::<f32>().unwrap();
-        let g = args.get_str("<g>").parse::<f32>().unwrap();
-        let b = args.get_str("<b>").parse::<f32>().unwrap();
+        let r = args.get_str("<r>").parse::<f32>()?;
+        let g = args.get_str("<g>").parse::<f32>()?;
+        let b = args.get_str("<b>").parse::<f32>()?;
         uniform(reader, header, args.get_str("<output>"), r, g, b);
     } else if args.get_bool("local") {
         local(reader, header, args.get_str("<output>"));
     }
+
+    Ok(())
 }
 
 fn uniform(reader: Reader, header: Header, write_to: &str, r: f32, g: f32, b: f32) {
@@ -62,28 +60,25 @@ fn uniform(reader: Reader, header: Header, write_to: &str, r: f32, g: f32, b: f3
 fn local(reader: Reader, header: Header, write_to: &str) {
     let mut writer = Writer::new(write_to, Some(header)).unwrap();
     for (streamline, mut scalars, properties) in reader.into_iter() {
-        // Scope to avoid scalars mutable sharing
-        {
-            let mut add = |p1: &Point, p2: &Point| {
-                let x = p2.x - p1.x;
-                let y = p2.y - p1.y;
-                let z = p2.z - p1.z;
-                let norm = (x.powi(2) + y.powi(2) + z.powi(2)).sqrt();
-                scalars.push((x / norm).abs() * 255.0);
-                scalars.push((y / norm).abs() * 255.0);
-                scalars.push((z / norm).abs() * 255.0);
-            };
+        let mut add = |p1: &Point, p2: &Point| {
+            let x = p2.x - p1.x;
+            let y = p2.y - p1.y;
+            let z = p2.z - p1.z;
+            let norm = (x.powi(2) + y.powi(2) + z.powi(2)).sqrt();
+            scalars.push((x / norm).abs() * 255.0);
+            scalars.push((y / norm).abs() * 255.0);
+            scalars.push((z / norm).abs() * 255.0);
+        };
 
-            // Manage first point
-            add(&streamline[0], &streamline[1]);
+        // Manage first point
+        add(&streamline[0], &streamline[1]);
 
-            for p in streamline.windows(3) {
-                add(&p[0], &p[2]);
-            }
-
-            // Manage last point
-            add(&streamline[streamline.len() - 2], &streamline[streamline.len() - 1]);
+        for p in streamline.windows(3) {
+            add(&p[0], &p[2]);
         }
+
+        // Manage last point
+        add(&streamline[streamline.len() - 2], &streamline[streamline.len() - 1]);
 
         writer.write((streamline, scalars, properties));
     }

--- a/examples/trk_header.rs
+++ b/examples/trk_header.rs
@@ -1,5 +1,6 @@
-use std::{fs::File, io::BufReader, path::Path, str};
+use std::{fs::File, io::BufReader};
 
+use anyhow::{Context, Result};
 use docopt::Docopt;
 
 use trk_io::CHeader;
@@ -13,30 +14,31 @@ Usage:
   trk_header (-v | --version)
 
 Options:
-  -a --all      Also print computed fields (endianness, affine, etc.)
-  -h --help     Show this screen.
-  -v --version  Show version.
+  -a --all       Also print computed fields (endianness, affine, etc.)
+  -h --help      Show this screen.
+  -v --version   Show version.
 ";
 
-fn main() {
+fn main() -> Result<()> {
     let version = String::from(env!("CARGO_PKG_VERSION"));
     let args = Docopt::new(USAGE)
         .and_then(|dopt| dopt.version(Some(version)).parse())
         .unwrap_or_else(|e| e.exit());
     let print_all = args.get_bool("--all");
-    let input = Path::new(args.get_str("<input>"));
-    if !input.exists() {
-        panic!("Input trk '{:?}' doesn't exist.", input);
-    }
 
-    let f = File::open(args.get_str("<input>")).expect("Can't read trk file.");
-    let mut reader = BufReader::new(f);
-    let (header, endianness) = CHeader::read(&mut reader).expect("Read header");
+    let path = args.get_str("<input>");
+    let mut reader =
+        BufReader::new(File::open(path).with_context(|| format!("Failed to load {:?}", path))?);
+    let (header, endianness) = CHeader::read(&mut reader)?;
 
     if print_all {
         println!("---------- Actual fields ----------");
     }
-    println!("id_string: {:?} ({})", header.id_string, str::from_utf8(&header.id_string).unwrap());
+    println!(
+        "id_string: {:?} ({})",
+        header.id_string,
+        std::str::from_utf8(&header.id_string).unwrap()
+    );
     println!("dim: {:?}", header.dim);
     println!("voxel_size: {:?}", header.voxel_size);
     println!("origin: {:?}", header.origin);
@@ -55,7 +57,7 @@ fn main() {
     println!(
         "voxel_order: {:?} ({})",
         header.voxel_order,
-        str::from_utf8(&header.voxel_order).unwrap()
+        std::str::from_utf8(&header.voxel_order).unwrap()
     );
     println!("image_orientation_patient: {:?}", header.image_orientation_patient);
     println!("invert: {:?} {:?} {:?}", header.invert_x, header.invert_y, header.invert_z);
@@ -66,10 +68,12 @@ fn main() {
 
     if print_all {
         let to_rasmm = header.get_affine_to_rasmm();
-        let to_trackvis = to_rasmm.try_inverse().unwrap();
+        let to_trackvis = to_rasmm.try_inverse().expect("Can't inverse affine");
         println!("\n---------- Computed fields ----------");
         println!("Endianness {}", endianness);
         print!("to rasmm {}", to_rasmm);
         print!("to to_trackvis {}", to_trackvis);
     }
+
+    Ok(())
 }

--- a/examples/trk_n_first.rs
+++ b/examples/trk_n_first.rs
@@ -1,4 +1,6 @@
+use anyhow::Result;
 use docopt::Docopt;
+
 use trk_io::{Point, Reader};
 
 static USAGE: &'static str = "
@@ -10,36 +12,31 @@ Usage:
   trk_n_first (-v | --version)
 
 Options:
-  -p --precision=<n>  Print `n` decimals. [default: 2]
-  -u --upto=<n>       Print up to `n` points per streamline. Will take the first `n / 2` and the
-                      last `n / 2` points. An odd number is ignored in favor of `n - 1`.
-                      Print all points if unspecified.
-  -h --help           Show this screen.
-  -v --version        Show version.
+  -p --precision=<n>   Print `n` decimals. [default: 2]
+  -u --upto=<n>        Print up to `n` points per streamline. Will take the first `n / 2` and the
+                       last `n / 2` points. An odd number is ignored in favor of `n - 1`.
+                       Print all points if unspecified.
+  -h --help            Show this screen.
+  -v --version         Show version.
 ";
 
-fn main() {
+fn main() -> Result<()> {
     let version = String::from(env!("CARGO_PKG_VERSION"));
     let args = Docopt::new(USAGE)
         .and_then(|dopt| dopt.version(Some(version)).parse())
         .unwrap_or_else(|e| e.exit());
 
-    let input = std::path::Path::new(args.get_str("<input>"));
-    if !input.exists() {
-        panic!("Input trk '{:?}' doesn't exist.", input);
-    }
-
-    let precision = args.get_str("--precision").parse::<usize>().unwrap();
+    let precision = args.get_str("--precision").parse::<usize>()?;
     let print = |p: &Point| {
         println!("({:.*} {:.*} {:.*})", precision, p[0], precision, p[1], precision, p[2]);
     };
 
     // nb - 1 because we don't want to print the last \n
-    let nb = args.get_str("<nb>").parse::<usize>().unwrap() - 1;
+    let nb = args.get_str("<nb>").parse::<usize>()? - 1;
     let upto = args.get_str("--upto").parse::<usize>().unwrap_or(std::usize::MAX);
     let first_part = upto / 2;
 
-    let reader = Reader::new(args.get_str("<input>")).expect("Read header");
+    let reader = Reader::new(args.get_str("<input>"))?;
     for (i, (streamline, _, _)) in reader.into_iter().enumerate() {
         let len = streamline.len();
         if len > upto {
@@ -57,4 +54,6 @@ fn main() {
         }
         println!("");
     }
+
+    Ok(())
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,9 +1,6 @@
-use std::{
-    fs::File,
-    io::{BufReader, Result},
-    path::Path,
-};
+use std::{fs::File, io::BufReader, path::Path};
 
+use anyhow::{Context, Result};
 use byteorder::WriteBytesExt;
 #[cfg(feature = "nifti_images")]
 use nifti::NiftiHeader;
@@ -46,7 +43,9 @@ impl Header {
 
     /// Retrieve a trk header, along with its byte order, from a file in the file system.
     pub fn from_trk<P: AsRef<Path>>(path: P) -> Result<Header> {
-        let mut reader = BufReader::new(File::open(&path)?);
+        let f = File::open(path.as_ref())
+            .with_context(|| format!("Failed to load {:?}", path.as_ref()))?;
+        let mut reader = BufReader::new(f);
         let (header, _) = Self::read(&mut reader)?;
         Ok(header)
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,9 +1,6 @@
-use std::{
-    fs::File,
-    io::{BufReader, Result},
-    path::Path,
-};
+use std::{fs::File, io::BufReader, path::Path};
 
+use anyhow::{Context, Result};
 use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use nalgebra::Vector3;
 
@@ -28,7 +25,9 @@ pub struct Reader {
 
 impl Reader {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Reader> {
-        let mut reader = BufReader::new(File::open(&path)?);
+        let f = File::open(path.as_ref())
+            .with_context(|| format!("Failed to load {:?}", path.as_ref()))?;
+        let mut reader = BufReader::new(f);
         let (header, endianness) = Header::read(&mut reader)?;
         let affine_to_rasmm = header.affine_to_rasmm;
         let translation = header.translation;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,9 +1,6 @@
-use std::{
-    fs::File,
-    io::{BufWriter, Result},
-    path::Path,
-};
+use std::{fs::File, io::BufWriter, path::Path};
 
+use anyhow::Result;
 use byteorder::WriteBytesExt;
 
 use crate::{


### PR DESCRIPTION
Simple replacement of `std::Result` with `anyhow::Result`. It does give better error messages, at least when we care to add "context". Of course the same can be achieved without `anyhow::Result` but this is becoming a de factor standard in the Rust community,